### PR TITLE
refactor: replace debug visualizers with Gizmos & simplify core logic

### DIFF
--- a/crates/souprune/src/app_state/battle/danmaku.rs
+++ b/crates/souprune/src/app_state/battle/danmaku.rs
@@ -258,11 +258,7 @@ fn battle_damage_detection_system(
             let damage = bullet_damage.0 as usize;
             let current_hp = layered_db.get_int("player_hp").unwrap_or(20) as usize;
             let hp_max = layered_db.get_int("player_hp_max").unwrap_or(20) as usize;
-            let new_hp = if current_hp > damage {
-                current_hp - damage
-            } else {
-                0
-            };
+            let new_hp = current_hp.saturating_sub(damage);
             layered_db.set_global("player_hp", new_hp as i64);
 
             // Start player invincibility

--- a/crates/souprune/src/app_state/battle/sequencer/view_element.rs
+++ b/crates/souprune/src/app_state/battle/sequencer/view_element.rs
@@ -140,9 +140,9 @@ fn apply_modification(
         }
         super::super::chapter_schema::ElementModification::SetPosition(x, y, z) => {
             if let Ok(mut transform) = transforms.get_mut(entity) {
-                let final_x = resolve_val_f32(x, Some(transform.translation.x), &player_data, None);
-                let final_y = resolve_val_f32(y, Some(transform.translation.y), &player_data, None);
-                let final_z = resolve_val_f32(z, Some(transform.translation.z), &player_data, None);
+                let final_x = resolve_val_f32(x, Some(transform.translation.x), player_data, None);
+                let final_y = resolve_val_f32(y, Some(transform.translation.y), player_data, None);
+                let final_z = resolve_val_f32(z, Some(transform.translation.z), player_data, None);
 
                 // Ensure history exists or create it
                 // 确保历史存在或创建它
@@ -180,9 +180,9 @@ fn apply_modification(
         }
         super::super::chapter_schema::ElementModification::SetScale(x, y, z) => {
             if let Ok(mut transform) = transforms.get_mut(entity) {
-                let final_x = resolve_val_f32(x, Some(transform.scale.x), &player_data, None);
-                let final_y = resolve_val_f32(y, Some(transform.scale.y), &player_data, None);
-                let final_z = resolve_val_f32(z, Some(transform.scale.z), &player_data, None);
+                let final_x = resolve_val_f32(x, Some(transform.scale.x), player_data, None);
+                let final_y = resolve_val_f32(y, Some(transform.scale.y), player_data, None);
+                let final_z = resolve_val_f32(z, Some(transform.scale.z), player_data, None);
 
                 transform.scale = Vec3::new(final_x, final_y, final_z);
                 info!(
@@ -195,10 +195,10 @@ fn apply_modification(
             if let Ok(mut sprite) = sprites.get_mut(entity) {
                 let color = sprite.color;
 
-                let final_r = resolve_val_f32(r, Some(color.to_srgba().red), &player_data, None);
-                let final_g = resolve_val_f32(g, Some(color.to_srgba().green), &player_data, None);
-                let final_b = resolve_val_f32(b, Some(color.to_srgba().blue), &player_data, None);
-                let final_a = resolve_val_f32(a, Some(color.to_srgba().alpha), &player_data, None);
+                let final_r = resolve_val_f32(r, Some(color.to_srgba().red), player_data, None);
+                let final_g = resolve_val_f32(g, Some(color.to_srgba().green), player_data, None);
+                let final_b = resolve_val_f32(b, Some(color.to_srgba().blue), player_data, None);
+                let final_a = resolve_val_f32(a, Some(color.to_srgba().alpha), player_data, None);
 
                 sprite.color = Color::srgba(final_r, final_g, final_b, final_a);
                 info!(
@@ -211,7 +211,7 @@ fn apply_modification(
             if let Ok(mut visibility) = visibilities.get_mut(entity) {
                 use crate::core::view::ron_view::parsing::resolve_val_bool;
 
-                let is_visible = resolve_val_bool(visible, &player_data);
+                let is_visible = resolve_val_bool(visible, player_data);
                 *visibility = if is_visible {
                     Visibility::Visible
                 } else {
@@ -222,8 +222,8 @@ fn apply_modification(
         }
         super::super::chapter_schema::ElementModification::SetBoxSize(width, height) => {
             if let Ok(mut ui_box) = ui_boxes.get_mut(entity) {
-                let w = resolve_val_f32(width, None, &player_data, None);
-                let h = resolve_val_f32(height, None, &player_data, None);
+                let w = resolve_val_f32(width, None, player_data, None);
+                let h = resolve_val_f32(height, None, player_data, None);
                 ui_box.width = w;
                 ui_box.height = h;
                 info!("Set box size for entity {:?}: {}x{}", entity, w, h);

--- a/crates/souprune/src/app_state/overworld/chase.rs
+++ b/crates/souprune/src/app_state/overworld/chase.rs
@@ -1098,11 +1098,7 @@ pub fn chase_damage_detection_system(
             let damage = bullet_damage.0 as usize;
             let current_hp = layered_db.get_int("player_hp").unwrap_or(20) as usize;
             let hp_max = layered_db.get_int("player_hp_max").unwrap_or(20) as usize;
-            let new_hp = if current_hp > damage {
-                current_hp - damage
-            } else {
-                0
-            };
+            let new_hp = current_hp.saturating_sub(damage);
             layered_db.set_global("player_hp", new_hp as i64);
 
             // Fire damage event

--- a/crates/souprune/src/app_state/overworld/trigger.rs
+++ b/crates/souprune/src/app_state/overworld/trigger.rs
@@ -173,16 +173,15 @@ pub fn load_fre_rules_system(
 
     // Try to find rules_file property in loaded maps
     for tiled_map in tiled_maps.iter() {
-        if let Some(map_asset) = tiled_map_assets.get(&tiled_map.0) {
-            if let Some(rules_prop) = map_asset.map.properties.get("rules_file") {
-                if let tiled::PropertyValue::StringValue(rules_path) = rules_prop {
-                    let handle: Handle<RuleSetAsset> = asset_server.load(rules_path.clone());
-                    loaded_rule_sets.handles.push(handle);
-                    loaded_rule_sets.initialized = true;
-                    info!("FRE: Loading rules from map property: {}", rules_path);
-                    return;
-                }
-            }
+        if let Some(map_asset) = tiled_map_assets.get(&tiled_map.0)
+            && let Some(rules_prop) = map_asset.map.properties.get("rules_file")
+            && let tiled::PropertyValue::StringValue(rules_path) = rules_prop
+        {
+            let handle: Handle<RuleSetAsset> = asset_server.load(rules_path.clone());
+            loaded_rule_sets.handles.push(handle);
+            loaded_rule_sets.initialized = true;
+            info!("FRE: Loading rules from map property: {}", rules_path);
+            return;
         }
     }
 

--- a/crates/souprune/src/extra/debug/collider.rs
+++ b/crates/souprune/src/extra/debug/collider.rs
@@ -232,15 +232,15 @@ pub mod debug_collider {
     ) {
         // Find SDF shapes with active masks and draw their bounds
         for material_handle in sdf_query.iter() {
-            if let Some(material) = sdf_materials.get(&material_handle.0) {
-                if material.uniform_data.mask_type > 0.5 {
-                    let params = material.uniform_data.mask_params;
-                    let center = Vec2::new(params.x, params.y);
-                    let size = Vec2::new(params.z * 2.0, params.w * 2.0);
-                    gizmos.rect_2d(Isometry2d::from_translation(center), size, css::RED);
-                    // Only draw the first mask found
-                    break;
-                }
+            if let Some(material) = sdf_materials.get(&material_handle.0)
+                && material.uniform_data.mask_type > 0.5
+            {
+                let params = material.uniform_data.mask_params;
+                let center = Vec2::new(params.x, params.y);
+                let size = Vec2::new(params.z * 2.0, params.w * 2.0);
+                gizmos.rect_2d(Isometry2d::from_translation(center), size, css::RED);
+                // Only draw the first mask found
+                break;
             }
         }
     }


### PR DESCRIPTION
### PR Type

*Please check the type of this PR (you can select multiple)*

- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation change
- [x] 🎨 Code style change (such as formatting, renaming)
- [x] ♻️ Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🧪 Adding or updating tests
- [ ] 🤖 CI/CD (Changes to CI/CD configuration)
- [ ] 📦 Other changes

### Related Issue

<!--
Please fill in the issue number related to this PR below.
For example: Closes #123
If there is no related issue, please fill in "None" or "N/A".
-->

- N/A

### What does this PR do?

<!--
Please briefly describe the main purpose and specific content of this PR.
For example:
- Fixed an issue where a specific component would cause a crash.
- Added a new system for handling player input.
-->

- **Debug Tools:** Completely refactored the collider debug visualization system (`crates/souprune/src/extra/debug/collider.rs`). Replaced the custom entity-based mesh visualization with Bevy's native `Gizmos` system. This removes the need for managing `ColliderDebugSettings` resource and `DebugVisualizerRoot` entities, resulting in cleaner and more maintainable code.
- **Code Simplification:**
  - Refactored HP calculation logic in `danmaku.rs` and `chase.rs` to use `saturating_sub` instead of manual `if-else` checks.
  - Flattened nested `if let` blocks using let chains (e.g., in `trigger.rs` and `collider.rs`).
  - Removed unnecessary references in `view_element.rs` for cleaner function calls.

### How to test?

<!--
If necessary, please describe in detail how the reviewer can verify your changes.
For example:
1. Run `cargo run` and verify the game starts without errors.
2. Test the new feature by performing specific actions.
3. Confirm that the expected behavior occurs.
-->

1. Run the game using `cargo run`.
2. Press **F3** to toggle the debug visualization.
3. Verify that colliders (player: green, walls: light green, triggers: cyan) are drawn correctly using the new Gizmos lines.
4. Verify that damage calculation works as expected in Battle and Overworld Chase modes.

### Screenshots or Videos

<!--
If your changes include visual changes or new features, please attach relevant screenshots or GIFs here so that the reviewer can visually understand the changes.
-->


### Additional Information

<!--
Any additional information you think needs to be explained.
-->
