### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_workbench"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",
@@ -7458,7 +7458,7 @@ dependencies = [
 
 [[package]]
 name = "souprune"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7546,7 +7546,7 @@ dependencies = [
 
 [[package]]
 name = "souprune_schema"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ron",
  "serde",

--- a/crates/souprune/CHANGELOG.md
+++ b/crates/souprune/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/Bli-AIk/souprune/compare/souprune-v0.5.1...souprune-v0.6.0) - 2026-03-19
+
+### Added
+
+- *(battle)* add animated merge with gap policy and easing support ([#88](https://github.com/Bli-AIk/souprune/pull/88))
+- [**breaking**] Battle System API Enhancement & Text Rendering Backend Overhaul ([#83](https://github.com/Bli-AIk/souprune/pull/83))
+- [**breaking**] Comprehensive FRE system refactor and animation/editor enhancements ([#78](https://github.com/Bli-AIk/souprune/pull/78))
+- *(editor)* add experimental souprune_editor crate with asset browser and view editor ([#77](https://github.com/Bli-AIk/souprune/pull/77))
+- Add Android platform support with touch controls and build pipeline ([#73](https://github.com/Bli-AIk/souprune/pull/73))
+- [**breaking**] Implement comprehensive dialogue system and restructure project layout ([#71](https://github.com/Bli-AIk/souprune/pull/71))
+- Integrate cargo-deny and optimize CI pipeline ([#59](https://github.com/Bli-AIk/souprune/pull/59))
+- [**breaking**] integrate Fact-Rule-Event system into battle and debug tools ([#45](https://github.com/Bli-AIk/souprune/pull/45))
+- [**breaking**] Unified Interactive View & Data-Driven Input System ([#44](https://github.com/Bli-AIk/souprune/pull/44))
+- *(battle)* Add Tween View Element Animation System ([#43](https://github.com/Bli-AIk/souprune/pull/43))
+- add ModifyViewElement command & refactor ui to view ([#41](https://github.com/Bli-AIk/souprune/pull/41))
+
+### Fixed
+
+- *(ci)* copy WIT files into each crate for cargo publish compatibility
+
+### Other
+
+- [**breaking**] view interaction system and generic sequence engine (breaking) ([#67](https://github.com/Bli-AIk/souprune/pull/67))
+
+### Refactor
+
+- [**breaking**] migrate mod system from C ABI to WASM Component Model ([#79](https://github.com/Bli-AIk/souprune/pull/79))
+- sequence-driven architecture with dynamic modes and extensible dispatch ([#75](https://github.com/Bli-AIk/souprune/pull/75))
+- [**breaking**] upgrade to Bevy 0.18 ([#66](https://github.com/Bli-AIk/souprune/pull/66))
+- [**breaking**] migrate HP bar to generic ShaderMaterial and introduce DynamicMaterial2d ([#65](https://github.com/Bli-AIk/souprune/pull/65))
+- *(view)* replace evalexpr with fasteval for expression evaluation ([#63](https://github.com/Bli-AIk/souprune/pull/63))
+- refactor!(view): adopt FRE-driven reconciliation view system ([#58](https://github.com/Bli-AIk/souprune/pull/58))
+- [**breaking**] Remove hardcoded paths and introduce unified Visual system ([#47](https://github.com/Bli-AIk/souprune/pull/47))
+- replace debug visualizers with Gizmos & simplify core logic ([#46](https://github.com/Bli-AIk/souprune/pull/46))
+- Replace bevy_smud with custom SDF rendering ([#42](https://github.com/Bli-AIk/souprune/pull/42))
+- Refactor RON backends to separate schema from logic ([#40](https://github.com/Bli-AIk/souprune/pull/40))
+
 ## [0.5.0](https://github.com/Bli-AIk/souprune/releases/tag/souprune-v0.5.0) - 2026-01-27
 
 ### Added

--- a/crates/souprune/Cargo.toml
+++ b/crates/souprune/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "souprune"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 authors = ["Bli-AIk <haikun2333@gmail.com>"]
 license = "LGPL-3.0-or-later"

--- a/crates/souprune_schema/CHANGELOG.md
+++ b/crates/souprune_schema/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/Bli-AIk/souprune/compare/souprune_schema-v0.1.0...souprune_schema-v0.2.0) - 2026-03-19
+
+### Added
+
+- [**breaking**] Battle System API Enhancement & Text Rendering Backend Overhaul ([#83](https://github.com/Bli-AIk/souprune/pull/83))

--- a/crates/souprune_schema/Cargo.toml
+++ b/crates/souprune_schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "souprune_schema"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Pure data schema types for SoupRune RON files. No Bevy dependency."


### PR DESCRIPTION



## 🤖 New release

* `souprune`: 0.5.1 -> 0.6.0 (✓ API compatible changes)
* `bevy_workbench`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `souprune_schema`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `souprune_schema` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SpriteDef.health_bar_source in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/view.rs:238
  field Item.mortar in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/item.rs:25
  field BulletPrototype.rotation in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/danmaku.rs:69

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum souprune_schema::view::HPBarSourceDef, previously in file /tmp/.tmphD2Jd8/souprune_schema/src/view.rs:244

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ItemType:KeyItem in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/item.rs:49
  variant Chapter:AlightMotionPerformance in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/sequence.rs:54
  variant ItemEffect:SetFact in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/item.rs:69
  variant RonFileKind:AlightMotionConfig in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/lib.rs:62
  variant RuleActionDef:StartDialogue in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/fre.rs:87
  variant RuleActionDef:UseItem in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/fre.rs:99
  variant RuleActionDef:CheckItem in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/fre.rs:102
  variant RuleActionDef:DropItem in /tmp/.tmpPyTDAy/souprune/crates/souprune_schema/src/fre.rs:105

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Chapter::AmPerformance, previously in file /tmp/.tmphD2Jd8/souprune_schema/src/sequence.rs:54
  variant RonFileKind::AmConfig, previously in file /tmp/.tmphD2Jd8/souprune_schema/src/lib.rs:62

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct souprune_schema::config::AmBattleConfig, previously in file /tmp/.tmphD2Jd8/souprune_schema/src/config.rs:180

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field hp_bar_source of struct SpriteDef, previously in file /tmp/.tmphD2Jd8/souprune_schema/src/view.rs:238
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `souprune`

<blockquote>

## [0.6.0](https://github.com/Bli-AIk/souprune/compare/souprune-v0.5.1...souprune-v0.6.0) - 2026-03-19

### Added

- *(battle)* add animated merge with gap policy and easing support ([#88](https://github.com/Bli-AIk/souprune/pull/88))
- [**breaking**] Battle System API Enhancement & Text Rendering Backend Overhaul ([#83](https://github.com/Bli-AIk/souprune/pull/83))
- [**breaking**] Comprehensive FRE system refactor and animation/editor enhancements ([#78](https://github.com/Bli-AIk/souprune/pull/78))
- *(editor)* add experimental souprune_editor crate with asset browser and view editor ([#77](https://github.com/Bli-AIk/souprune/pull/77))
- Add Android platform support with touch controls and build pipeline ([#73](https://github.com/Bli-AIk/souprune/pull/73))
- [**breaking**] Implement comprehensive dialogue system and restructure project layout ([#71](https://github.com/Bli-AIk/souprune/pull/71))
- Integrate cargo-deny and optimize CI pipeline ([#59](https://github.com/Bli-AIk/souprune/pull/59))
- [**breaking**] integrate Fact-Rule-Event system into battle and debug tools ([#45](https://github.com/Bli-AIk/souprune/pull/45))
- [**breaking**] Unified Interactive View & Data-Driven Input System ([#44](https://github.com/Bli-AIk/souprune/pull/44))
- *(battle)* Add Tween View Element Animation System ([#43](https://github.com/Bli-AIk/souprune/pull/43))
- add ModifyViewElement command & refactor ui to view ([#41](https://github.com/Bli-AIk/souprune/pull/41))

### Fixed

- *(ci)* copy WIT files into each crate for cargo publish compatibility

### Other

- [**breaking**] view interaction system and generic sequence engine (breaking) ([#67](https://github.com/Bli-AIk/souprune/pull/67))

### Refactor

- [**breaking**] migrate mod system from C ABI to WASM Component Model ([#79](https://github.com/Bli-AIk/souprune/pull/79))
- sequence-driven architecture with dynamic modes and extensible dispatch ([#75](https://github.com/Bli-AIk/souprune/pull/75))
- [**breaking**] upgrade to Bevy 0.18 ([#66](https://github.com/Bli-AIk/souprune/pull/66))
- [**breaking**] migrate HP bar to generic ShaderMaterial and introduce DynamicMaterial2d ([#65](https://github.com/Bli-AIk/souprune/pull/65))
- *(view)* replace evalexpr with fasteval for expression evaluation ([#63](https://github.com/Bli-AIk/souprune/pull/63))
- refactor!(view): adopt FRE-driven reconciliation view system ([#58](https://github.com/Bli-AIk/souprune/pull/58))
- [**breaking**] Remove hardcoded paths and introduce unified Visual system ([#47](https://github.com/Bli-AIk/souprune/pull/47))
- replace debug visualizers with Gizmos & simplify core logic ([#46](https://github.com/Bli-AIk/souprune/pull/46))
- Replace bevy_smud with custom SDF rendering ([#42](https://github.com/Bli-AIk/souprune/pull/42))
- Refactor RON backends to separate schema from logic ([#40](https://github.com/Bli-AIk/souprune/pull/40))
</blockquote>

## `bevy_workbench`

<blockquote>

## [0.3.2](https://github.com/Bli-AIk/souprune/compare/bevy_workbench-v0.3.1...bevy_workbench-v0.3.2) - 2026-03-19

### Added

- *(editor)* add experimental souprune_editor crate with asset browser and view editor ([#77](https://github.com/Bli-AIk/souprune/pull/77))
</blockquote>

## `souprune_schema`

<blockquote>

## [0.2.0](https://github.com/Bli-AIk/souprune/compare/souprune_schema-v0.1.0...souprune_schema-v0.2.0) - 2026-03-19

### Added

- [**breaking**] Battle System API Enhancement & Text Rendering Backend Overhaul ([#83](https://github.com/Bli-AIk/souprune/pull/83))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).