### PR TITLE
refactor!(overworld): unify trigger system and fix dialogue/puzzle bugs

### DIFF
--- a/crates/souprune/src/config.rs
+++ b/crates/souprune/src/config.rs
@@ -189,6 +189,14 @@ pub struct GameConfig {
     /// 若 `initial_sequence_path` 已设置，模式从序列中推导；否则使用此值。
     #[serde(default = "default_initial_mode")]
     pub initial_mode: String,
+
+    /// FRE rule files loaded for overworld state (accumulated from dependency chain).
+    /// Rules from dependency mods come first, main mod's rules last.
+    ///
+    /// Overworld 状态加载的 FRE 规则文件（从依赖链累积）。
+    /// 依赖 mod 的规则在前，主 mod 的规则在后。
+    #[serde(default)]
+    pub overworld_rules: Vec<String>,
 }
 
 fn default_initial_mode() -> String {
@@ -210,6 +218,7 @@ impl Default for GameConfig {
             required_modules: vec!["overworld".to_string(), "common".to_string()],
             hidden_layer_keywords: vec!["prototype".to_string(), "collision".to_string()],
             initial_mode: default_initial_mode(),
+            overworld_rules: Vec::new(),
         }
     }
 }
@@ -419,6 +428,7 @@ struct ModGameConfig {
     required_modules: Option<Vec<String>>,
     hidden_layer_keywords: Option<Vec<String>>,
     initial_mode: Option<String>,
+    overworld_rules: Option<Vec<String>>,
 }
 
 fn read_mod_config<P: AsRef<Path>>(path: P) -> Result<ModConfigFile> {
@@ -461,6 +471,10 @@ fn apply_mod_config(config: &mut SoupruneConfig, mod_cfg: ModConfigFile) {
         merge!(required_modules);
         merge!(hidden_layer_keywords);
         merge!(initial_mode);
+        // overworld_rules: extend rather than overwrite (dependency chain accumulation)
+        if let Some(val) = g.overworld_rules {
+            config.game.overworld_rules.extend(val);
+        }
         // Option<T> fields: wrap in Some
         if let Some(val) = g.initial_sequence_path {
             config.game.initial_sequence_path = Some(val);

--- a/crates/souprune/src/core/dialogue.rs
+++ b/crates/souprune/src/core/dialogue.rs
@@ -143,14 +143,6 @@ fn init_dialogue_facts(mut facts: ResMut<LayeredFactDatabase>) {
 
     // Dialogue configuration facts
     // 对话配置 facts
-    facts.set_global(
-        fre_facts::DIALOGUE_SIMPLE_TEXT_ACTIVE,
-        FactValue::Bool(false),
-    );
-    facts.set_global(
-        fre_facts::DIALOGUE_SIMPLE_TEXT,
-        FactValue::String(String::new()),
-    );
     facts.set_global(fre_facts::DIALOGUE_HAS_TYPEWRITER, FactValue::Bool(true));
 
     // Auto-pause default state (enabled by default; disabled if no config loaded)

--- a/crates/souprune/src/core/dialogue/config.rs
+++ b/crates/souprune/src/core/dialogue/config.rs
@@ -37,12 +37,12 @@ impl Default for DialogueInputConfig {
 
 // Note: ActiveDialogueState has been removed.
 // Dialogue state is now managed via FRE facts:
-// - dialogue:simple_text_active (Bool) - whether simple text dialogue is active
-// - dialogue:simple_text (String) - the simple text content
+// - dialogue:active (Bool) - whether dialogue is active
 // - dialogue:has_typewriter (Bool) - whether typewriter is enabled
+// - dialogue:has_mortar (Bool) - whether mortar VM is driving the dialogue
 //
 // 注意：ActiveDialogueState 已被移除。
 // 对话状态现在通过 FRE facts 管理：
-// - dialogue:simple_text_active (Bool) - 简单文本对话是否激活
-// - dialogue:simple_text (String) - 简单文本内容
+// - dialogue:active (Bool) - 对话是否激活
 // - dialogue:has_typewriter (Bool) - 是否启用打字机
+// - dialogue:has_mortar (Bool) - 是否由 Mortar VM 驱动对话

--- a/crates/souprune/src/core/dialogue/systems/input.rs
+++ b/crates/souprune/src/core/dialogue/systems/input.rs
@@ -13,7 +13,7 @@
 
 use bevy::prelude::*;
 use bevy_ecs_typewriter::{Typewriter, TypewriterState};
-use bevy_fact_rule_event::{FactEvent, FactValue, LayeredFactDatabase};
+use bevy_fact_rule_event::{FactEvent, LayeredFactDatabase};
 use bevy_mortar_bond::{MortarEvent, MortarRuntime};
 
 use super::lifecycle::DialogueControllerEntity;
@@ -28,7 +28,7 @@ pub fn dialogue_advance_system(
     mut fre_events: MessageReader<FactEvent>,
     config: Res<DialogueInputConfig>,
     mut mortar_events: MessageWriter<MortarEvent>,
-    mut facts: ResMut<LayeredFactDatabase>,
+    facts: Res<LayeredFactDatabase>,
     query: Query<&Typewriter, With<DialogueControllerEntity>>,
     runtime: Res<MortarRuntime>,
 ) {
@@ -53,11 +53,8 @@ pub fn dialogue_advance_system(
         );
 
         let mortar_active = runtime.has_active_dialogues();
-        let simple_active = facts
-            .get_bool(fre_facts::DIALOGUE_SIMPLE_TEXT_ACTIVE)
-            .unwrap_or(false);
 
-        if !mortar_active && !simple_active {
+        if !mortar_active {
             info!("dialogue_advance_system: no active dialogue, skipping");
             continue;
         }
@@ -67,11 +64,6 @@ pub fn dialogue_advance_system(
             if mortar_active {
                 info!("dialogue_advance_system: no typewriters, sending NextText");
                 mortar_events.write(MortarEvent::next_text());
-            } else {
-                info!(
-                    "dialogue_advance_system: simple text (no typewriter), marking dialogue ended"
-                );
-                facts.set(fre_facts::DIALOGUE_PENDING_ENDED, FactValue::Bool(true));
             }
             continue;
         }
@@ -101,9 +93,6 @@ pub fn dialogue_advance_system(
 
         if mortar_active {
             mortar_events.write(MortarEvent::next_text());
-        } else {
-            info!("dialogue_advance_system: simple text finished, marking dialogue ended");
-            facts.set(fre_facts::DIALOGUE_PENDING_ENDED, FactValue::Bool(true));
         }
     }
 }

--- a/crates/souprune/src/core/dialogue/systems/lifecycle.rs
+++ b/crates/souprune/src/core/dialogue/systems/lifecycle.rs
@@ -17,7 +17,6 @@ use bevy_fact_rule_event::{FactEvent, FactValue, LayeredFactDatabase};
 use bevy_mortar_bond::{MortarDialogueFinished, MortarEvent, MortarRuntime};
 
 use crate::core::fre_facts;
-use crate::core::view::components::{ActiveView, ViewRoot};
 
 use super::super::auto_pause::AutoPauseState;
 
@@ -62,14 +61,9 @@ pub fn spawn_dialogue_controller_system(
     runtime: Res<MortarRuntime>,
     query: Query<Entity, With<DialogueControllerEntity>>,
     facts: Res<LayeredFactDatabase>,
-    mut active_view_query: Query<&mut ViewRoot, With<ActiveView>>,
 ) {
     let has_controller = !query.is_empty();
     let dialogue_active = facts.get_bool(fre_facts::DIALOGUE_ACTIVE).unwrap_or(false);
-    let simple_text_active = facts
-        .get_bool(fre_facts::DIALOGUE_SIMPLE_TEXT_ACTIVE)
-        .unwrap_or(false);
-    let has_dialogue = dialogue_active || simple_text_active;
     let has_typewriter = facts
         .get_bool(fre_facts::DIALOGUE_HAS_TYPEWRITER)
         .unwrap_or(true);
@@ -78,21 +72,20 @@ pub fn spawn_dialogue_controller_system(
         .unwrap_or(false)
         || runtime.has_active_dialogues();
 
-    if dialogue_active || simple_text_active || has_controller || runtime.has_active_dialogues() {
+    if dialogue_active || has_controller || runtime.has_active_dialogues() {
         debug!(
-            "spawn_dialogue_controller_system: dialogue_active={}, simple_text_active={}, has_controller={}, has_mortar={}, runtime_active={}",
+            "spawn_dialogue_controller_system: dialogue_active={}, has_controller={}, has_mortar={}, runtime_active={}",
             dialogue_active,
-            simple_text_active,
             has_controller,
             has_mortar,
             runtime.has_active_dialogues()
         );
     }
 
-    if has_dialogue && !has_controller {
+    if dialogue_active && !has_controller {
         info!(
-            "spawn_dialogue_controller_system: spawning dialogue controller (mortar={}, simple_text={}, typewriter={})",
-            has_mortar, simple_text_active, has_typewriter
+            "spawn_dialogue_controller_system: spawning dialogue controller (mortar={}, typewriter={})",
+            has_mortar, has_typewriter
         );
 
         let mut entity_commands = commands.spawn(DialogueControllerEntity);
@@ -106,26 +99,11 @@ pub fn spawn_dialogue_controller_system(
         }
 
         if has_typewriter {
-            let simple_text = facts
-                .get_string(fre_facts::DIALOGUE_SIMPLE_TEXT)
-                .map(|s| s.to_string());
-            let initial_text = if !has_mortar {
-                simple_text.unwrap_or_default()
-            } else {
-                String::new()
-            };
             let typewriter_speed = facts
                 .get_float(fre_facts::DIALOGUE_TYPEWRITER_SPEED)
                 .map(|n| n as f32)
                 .unwrap_or(0.03);
-            let mut typewriter = Typewriter::new(&initial_text, typewriter_speed);
-            if !initial_text.is_empty() {
-                typewriter.play();
-                info!(
-                    "spawn_dialogue_controller_system: starting typewriter with simple_text: '{}'",
-                    initial_text
-                );
-            }
+            let typewriter = Typewriter::new("", typewriter_speed);
             entity_commands.insert(typewriter);
 
             if let Some(voice_path) = facts.get_string(fre_facts::DIALOGUE_VOICE)
@@ -136,22 +114,6 @@ pub fn spawn_dialogue_controller_system(
                     voice_path
                 );
                 entity_commands.insert(super::super::components::TypewriterVoice::new(voice_path));
-            }
-        }
-
-        if !has_mortar
-            && !has_typewriter
-            && let Some(text) = facts.get_string(fre_facts::DIALOGUE_SIMPLE_TEXT)
-        {
-            info!(
-                "spawn_dialogue_controller_system: setting simple_text to View local_facts: '{}'",
-                text
-            );
-            let text_owned = text.to_string();
-            for mut view_root in active_view_query.iter_mut() {
-                view_root
-                    .local_facts
-                    .set("dialogue_text", FactValue::String(text_owned.clone()));
             }
         }
     }
@@ -181,18 +143,13 @@ pub fn despawn_dialogue_controller_system(
 
     if !should_cleanup {
         let mortar_active = runtime.has_active_dialogues();
-        let simple_active = facts
-            .bypass_change_detection()
-            .get_bool(fre_facts::DIALOGUE_SIMPLE_TEXT_ACTIVE)
-            .unwrap_or(false);
         let dialogue_active_fact = facts
             .bypass_change_detection()
             .get_bool(fre_facts::DIALOGUE_ACTIVE)
             .unwrap_or(false);
         let has_controller = !query.is_empty();
 
-        should_cleanup =
-            has_controller && !mortar_active && !simple_active && !dialogue_active_fact;
+        should_cleanup = has_controller && !mortar_active && !dialogue_active_fact;
     }
 
     if !should_cleanup {
@@ -294,11 +251,7 @@ pub fn handle_pending_dialogue_start_system(
         mortar_events.write(MortarEvent::start_node(localized_path, node));
     }
 
-    let simple_text_active = facts
-        .bypass_change_detection()
-        .get_bool(fre_facts::DIALOGUE_SIMPLE_TEXT_ACTIVE)
-        .unwrap_or(false);
-    let dialogue_active = has_mortar || simple_text_active;
+    let dialogue_active = has_mortar;
     facts.set(fre_facts::DIALOGUE_ACTIVE, FactValue::Bool(dialogue_active));
     facts.set(fre_facts::DIALOGUE_HAS_MORTAR, FactValue::Bool(has_mortar));
     fre_event_writer.write(FactEvent::new(fre_facts::DIALOGUE_STARTED));

--- a/crates/souprune/src/core/fre_bridge.rs
+++ b/crates/souprune/src/core/fre_bridge.rs
@@ -25,6 +25,7 @@ pub use extensions::ViewActionExtensions;
 pub use view_actions::process_view_actions_system;
 
 use bevy::prelude::*;
+use bevy_fact_rule_event::FRESystemSet;
 use std::collections::HashMap;
 
 /// Event emitted for each FRE Custom action encountered during rule evaluation.
@@ -63,7 +64,9 @@ impl Plugin for FREBridgePlugin {
                     custom_dispatch::dispatch_custom_actions_system,
                     view_actions::handle_switch_state_system,
                 )
-                    .chain(),
+                    .chain()
+                    .after(FRESystemSet::EmitEvents)
+                    .before(FRESystemSet::ProcessRules),
             );
     }
 }

--- a/crates/souprune/src/core/fre_bridge/custom_dispatch.rs
+++ b/crates/souprune/src/core/fre_bridge/custom_dispatch.rs
@@ -13,8 +13,9 @@
 
 use super::{FreCustomActionEvent, evaluate_conditions};
 use bevy::prelude::*;
-use bevy_fact_rule_event::{EnumRegistry, FactEvent, LayeredFactDatabase};
+use bevy_fact_rule_event::{EnumRegistry, FactEvent, FactValue, LayeredFactDatabase};
 
+use crate::core::fre_facts;
 use crate::core::game_action::{
     GameActionDef, GameActionHandlerRegistry, GameRule, GameRuleRegistry,
 };
@@ -22,41 +23,80 @@ use crate::core::game_action::{
 fn dispatch_single_custom_action(
     action: &GameActionDef,
     rule: &GameRule,
-    fact_db: &LayeredFactDatabase,
+    fact_db: &mut LayeredFactDatabase,
     handler_registry: &GameActionHandlerRegistry,
     commands: &mut Commands,
     custom_action_writer: &mut MessageWriter<FreCustomActionEvent>,
 ) {
-    let GameActionDef::Custom {
-        action_type,
-        params,
-    } = action
-    else {
-        return;
-    };
-
-    if handler_registry.has_handler(action_type) {
-        debug!(
-            "FRE: Executing registered handler for '{}' (rule: '{}')",
-            action_type, rule.id
-        );
-        handler_registry.execute(action, fact_db, commands);
-    } else {
-        debug!(
-            "FRE: Dispatching unhandled custom action '{}' (rule: '{}')",
-            action_type, rule.id
-        );
-        custom_action_writer.write(FreCustomActionEvent {
-            action_type: action_type.clone(),
-            params: params.clone(),
-        });
+    match action {
+        GameActionDef::StartDialogue {
+            mortar,
+            node,
+            view,
+            typewriter,
+            focus,
+            voice,
+        } => {
+            info!(
+                "FRE: StartDialogue(mortar: {}, node: {}) from rule '{}'",
+                mortar, node, rule.id
+            );
+            fact_db.set_local(
+                fre_facts::DIALOGUE_PENDING_MORTAR_PATH,
+                FactValue::String(mortar.clone()),
+            );
+            fact_db.set_local(
+                fre_facts::DIALOGUE_PENDING_MORTAR_NODE,
+                FactValue::String(node.clone()),
+            );
+            if let Some(view_path) = view {
+                fact_db.set_local(
+                    fre_facts::DIALOGUE_PENDING_VIEW,
+                    FactValue::String(view_path.clone()),
+                );
+            }
+            fact_db.set_local(
+                fre_facts::DIALOGUE_HAS_TYPEWRITER,
+                FactValue::Bool(*typewriter),
+            );
+            fact_db.set_local(fre_facts::DIALOGUE_HAS_FOCUS, FactValue::Bool(*focus));
+            if let Some(voice_path) = voice {
+                fact_db.set_local(
+                    fre_facts::DIALOGUE_VOICE,
+                    FactValue::String(voice_path.clone()),
+                );
+            }
+            fact_db.set_local(fre_facts::DIALOGUE_PENDING_START, FactValue::Bool(true));
+        }
+        GameActionDef::Custom {
+            action_type,
+            params,
+        } => {
+            if handler_registry.has_handler(action_type) {
+                debug!(
+                    "FRE: Executing registered handler for '{}' (rule: '{}')",
+                    action_type, rule.id
+                );
+                handler_registry.execute(action, fact_db, commands);
+            } else {
+                debug!(
+                    "FRE: Dispatching unhandled custom action '{}' (rule: '{}')",
+                    action_type, rule.id
+                );
+                custom_action_writer.write(FreCustomActionEvent {
+                    action_type: action_type.clone(),
+                    params: params.clone(),
+                });
+            }
+        }
+        _ => {}
     }
 }
 
 fn dispatch_event_custom_actions(
     event: &FactEvent,
     rule_registry: &GameRuleRegistry,
-    fact_db: &LayeredFactDatabase,
+    fact_db: &mut LayeredFactDatabase,
     handler_registry: &GameActionHandlerRegistry,
     commands: &mut Commands,
     custom_action_writer: &mut MessageWriter<FreCustomActionEvent>,
@@ -108,7 +148,7 @@ fn dispatch_event_custom_actions(
 pub fn dispatch_custom_actions_system(
     mut events: MessageReader<FactEvent>,
     rule_registry: Res<GameRuleRegistry>,
-    fact_db: Res<LayeredFactDatabase>,
+    mut fact_db: ResMut<LayeredFactDatabase>,
     handler_registry: Res<GameActionHandlerRegistry>,
     mut commands: Commands,
     mut custom_action_writer: MessageWriter<FreCustomActionEvent>,
@@ -120,7 +160,7 @@ pub fn dispatch_custom_actions_system(
         dispatch_event_custom_actions(
             event,
             &rule_registry,
-            &fact_db,
+            &mut fact_db,
             &handler_registry,
             &mut commands,
             &mut custom_action_writer,

--- a/crates/souprune/src/core/fre_bridge/eval/expressions.rs
+++ b/crates/souprune/src/core/fre_bridge/eval/expressions.rs
@@ -112,6 +112,9 @@ pub(super) fn resolve_int(expr: &str, facts: &dyn FactReader) -> Option<i64> {
         if let Some(val) = facts.get_int(var_name) {
             return Some(val);
         }
+        if let Some(FactValue::Bool(b)) = facts.get_by_str(var_name) {
+            return Some(if *b { 1 } else { 0 });
+        }
         if let Some(val) = facts.get_by_str(var_name)
             && let FactValue::StringList(list) = val
         {

--- a/crates/souprune/src/core/fre_bridge/eval/expressions.rs
+++ b/crates/souprune/src/core/fre_bridge/eval/expressions.rs
@@ -112,6 +112,8 @@ pub(super) fn resolve_int(expr: &str, facts: &dyn FactReader) -> Option<i64> {
         if let Some(val) = facts.get_int(var_name) {
             return Some(val);
         }
+        // Bool → i64 coercion: true=1, false=0 (enables arithmetic on bool facts)
+        // Bool → i64 强制转换：true=1, false=0（允许对布尔 fact 进行算术运算）
         if let Some(FactValue::Bool(b)) = facts.get_by_str(var_name) {
             return Some(if *b { 1 } else { 0 });
         }

--- a/crates/souprune/src/core/fre_bridge/view_actions.rs
+++ b/crates/souprune/src/core/fre_bridge/view_actions.rs
@@ -258,6 +258,7 @@ fn execute_action(
         }
         GameActionDef::StartDialogue { .. } => {
             // Handled by dispatch_custom_actions_system — skip here.
+            // 由 dispatch_custom_actions_system 处理 — 此处跳过。
         }
         GameActionDef::Custom {
             action_type,

--- a/crates/souprune/src/core/fre_bridge/view_actions.rs
+++ b/crates/souprune/src/core/fre_bridge/view_actions.rs
@@ -256,44 +256,8 @@ fn execute_action(
         GameActionDef::EmitEvent(event_id) => {
             debug!("FRE Bridge: EmitEvent({})", event_id);
         }
-        GameActionDef::StartDialogue {
-            mortar,
-            node,
-            view,
-            typewriter,
-            focus,
-            voice,
-        } => {
-            info!(
-                "FRE Bridge: StartDialogue(mortar: {}, node: {})",
-                mortar, node
-            );
-            global_facts.set_local(
-                fre_facts::DIALOGUE_PENDING_MORTAR_PATH,
-                FactValue::String(mortar.clone()),
-            );
-            global_facts.set_local(
-                fre_facts::DIALOGUE_PENDING_MORTAR_NODE,
-                FactValue::String(node.clone()),
-            );
-            if let Some(view_path) = view {
-                global_facts.set_local(
-                    fre_facts::DIALOGUE_PENDING_VIEW,
-                    FactValue::String(view_path.clone()),
-                );
-            }
-            global_facts.set_local(
-                fre_facts::DIALOGUE_HAS_TYPEWRITER,
-                FactValue::Bool(*typewriter),
-            );
-            global_facts.set_local(fre_facts::DIALOGUE_HAS_FOCUS, FactValue::Bool(*focus));
-            if let Some(voice_path) = voice {
-                global_facts.set_local(
-                    fre_facts::DIALOGUE_VOICE,
-                    FactValue::String(voice_path.clone()),
-                );
-            }
-            global_facts.set_local(fre_facts::DIALOGUE_PENDING_START, FactValue::Bool(true));
+        GameActionDef::StartDialogue { .. } => {
+            // Handled by dispatch_custom_actions_system — skip here.
         }
         GameActionDef::Custom {
             action_type,

--- a/crates/souprune/src/core/fre_facts.rs
+++ b/crates/souprune/src/core/fre_facts.rs
@@ -22,10 +22,6 @@ pub const DIALOGUE_TYPEWRITER_PLAYING: &str = "dialogue:typewriter_playing";
 pub const DIALOGUE_ALL_TYPEWRITERS_FINISHED: &str = "dialogue:all_typewriters_finished";
 /// 是否有任意打字机已完成
 pub const DIALOGUE_ANY_TYPEWRITER_FINISHED: &str = "dialogue:any_typewriter_finished";
-/// 简单文本模式是否激活
-pub const DIALOGUE_SIMPLE_TEXT_ACTIVE: &str = "dialogue:simple_text_active";
-/// 简单文本内容
-pub const DIALOGUE_SIMPLE_TEXT: &str = "dialogue:simple_text";
 /// 是否使用打字机效果
 pub const DIALOGUE_HAS_TYPEWRITER: &str = "dialogue:has_typewriter";
 /// 触发对话启动的待处理标志

--- a/crates/souprune/src/core/map_property_schema.rs
+++ b/crates/souprune/src/core/map_property_schema.rs
@@ -28,9 +28,13 @@
 //!
 //! | Property Key | Type | Required | Description |
 //! |--------------|------|----------|-------------|
-//! | `collision` | String | No | Collision type ("solid", "semi-solid", etc.) |
-//! | `trigger` | String | No | Trigger zone type |
-//! | `trigger_id` | String | No | Unique identifier for the trigger |
+//! | `kind` | String | No | Object kind(s): "collision", "confirm", "enter", "exit", or comma-separated |
+//! | `mortar` | String | No | Mortar script file path for dialogue |
+//! | `mortar_node` | String | No | Mortar node entry point (default: object name) |
+//! | `view` | String | No | View layout file path for dialogue |
+//! | `focus` | Bool | No | Focus on dialogue (default: true) |
+//! | `typewriter` | Bool | No | Typewriter mode (default: true) |
+//! | `voice` | String | No | Voice audio path for dialogue |
 
 use bevy::prelude::*;
 use bevy_ecs_tiled::prelude::tiled;
@@ -67,25 +71,40 @@ pub mod object_keys {
     /// 摄像机边界区域标记。
     pub const CAMERA_BOUNDS: &str = "camera_bounds";
 
-    /// Collision type for the object.
+    /// Object kind(s) — comma-separated: "collision", "confirm", "enter", "exit".
     ///
-    /// 对象的碰撞类型。
-    pub const COLLISION: &str = "collision";
+    /// 对象类型 — 逗号分隔: "collision", "confirm", "enter", "exit"。
+    pub const KIND: &str = "kind";
 
-    /// Trigger zone type.
+    /// Mortar script file path for dialogue.
     ///
-    /// 触发区域类型。
-    pub const TRIGGER: &str = "trigger";
+    /// 对话用的 Mortar 脚本文件路径。
+    pub const MORTAR: &str = "mortar";
 
-    /// Trigger zone ID (for identifying which trigger was activated).
+    /// Mortar node entry point (default: object name).
     ///
-    /// 触发区域 ID（用于识别哪个触发器被激活）。
-    pub const TRIGGER_ID: &str = "trigger_id";
+    /// Mortar 节点入口（默认：对象名称）。
+    pub const MORTAR_NODE: &str = "mortar_node";
 
-    /// Interactable object type.
+    /// View layout file path for dialogue.
     ///
-    /// 可交互物体类型。
-    pub const INTERACTABLE: &str = "interactable";
+    /// 对话视图布局文件路径。
+    pub const VIEW: &str = "view";
+
+    /// Focus on dialogue (default: true).
+    ///
+    /// 是否聚焦对话（默认：true）。
+    pub const FOCUS: &str = "focus";
+
+    /// Typewriter mode (default: true).
+    ///
+    /// 是否启用打字机效果（默认：true）。
+    pub const TYPEWRITER: &str = "typewriter";
+
+    /// Voice audio path for dialogue.
+    ///
+    /// 对话语音音频路径。
+    pub const VOICE: &str = "voice";
 }
 
 /// Property definition for validation purposes.
@@ -138,20 +157,44 @@ pub static OBJECT_PROPERTIES: &[PropertyDef] = &[
         default: None,
     },
     PropertyDef {
-        key: object_keys::COLLISION,
-        description: "Collision type for the object (solid, semi-solid, etc.)",
+        key: object_keys::KIND,
+        description: "Object kind(s): collision, confirm, enter, exit (comma-separated)",
         required: false,
         default: None,
     },
     PropertyDef {
-        key: object_keys::TRIGGER,
-        description: "Trigger zone type",
+        key: object_keys::MORTAR,
+        description: "Mortar script file path for dialogue",
         required: false,
         default: None,
     },
     PropertyDef {
-        key: object_keys::INTERACTABLE,
-        description: "Interactable object type",
+        key: object_keys::MORTAR_NODE,
+        description: "Mortar node entry point (default: object name)",
+        required: false,
+        default: None,
+    },
+    PropertyDef {
+        key: object_keys::VIEW,
+        description: "View layout file path for dialogue",
+        required: false,
+        default: None,
+    },
+    PropertyDef {
+        key: object_keys::FOCUS,
+        description: "Focus on dialogue (default: true)",
+        required: false,
+        default: Some("true"),
+    },
+    PropertyDef {
+        key: object_keys::TYPEWRITER,
+        description: "Typewriter mode (default: true)",
+        required: false,
+        default: Some("true"),
+    },
+    PropertyDef {
+        key: object_keys::VOICE,
+        description: "Voice audio path for dialogue",
         required: false,
         default: None,
     },

--- a/crates/souprune/src/core/map_property_schema.rs
+++ b/crates/souprune/src/core/map_property_schema.rs
@@ -86,69 +86,6 @@ pub mod object_keys {
     ///
     /// 可交互物体类型。
     pub const INTERACTABLE: &str = "interactable";
-
-    // ========================================
-    // Dialogue Component Properties
-    // 对话组件属性
-    // ========================================
-
-    /// Path to Mortar dialogue file (relative to locales).
-    /// Example: "overworld/dialogue.mortar"
-    ///
-    /// Mortar 对话文件路径（相对于 locales）。
-    /// 示例："overworld/dialogue.mortar"
-    pub const DIALOGUE_PATH: &str = "dialogue_path";
-
-    /// Node name in the Mortar file to start dialogue.
-    /// Required when dialogue_path is set.
-    ///
-    /// 启动对话的 Mortar 文件中的节点名。
-    /// 当设置了 dialogue_path 时必须。
-    pub const DIALOGUE_NODE: &str = "dialogue_node";
-
-    /// Whether to use typewriter effect for this dialogue.
-    /// Default: true
-    ///
-    /// 是否为此对话使用打字机效果。
-    /// 默认：true
-    pub const HAS_TYPEWRITER: &str = "has_typewriter";
-
-    /// Whether to use Mortar controller (for dynamic dialogue).
-    /// Default: true
-    ///
-    /// 是否使用 Mortar 控制器（用于动态对话）。
-    /// 默认：true
-    pub const HAS_MORTAR: &str = "has_mortar";
-
-    /// Simple text content for non-Mortar dialogue.
-    /// Used when has_mortar is false.
-    ///
-    /// 非 Mortar 对话的简单文本内容。
-    /// 当 has_mortar 为 false 时使用。
-    pub const SIMPLE_TEXT: &str = "simple_text";
-
-    /// View layout file for dialogue UI.
-    /// Default: "overworld/view/dialogue.view.ron"
-    ///
-    /// 对话 UI 的 View 布局文件。
-    /// 默认："overworld/view/dialogue.view.ron"
-    pub const DIALOGUE_VIEW: &str = "dialogue_view";
-
-    /// Voice sound effect for typewriter.
-    /// Path to audio file (relative to assets).
-    /// Example: "audio/voice/voice_monster.wav"
-    ///
-    /// 打字机音效。
-    /// 音频文件路径（相对于 assets）。
-    /// 示例："audio/voice/voice_monster.wav"
-    pub const DIALOGUE_VOICE: &str = "dialogue_voice";
-
-    /// Typewriter speed in seconds per character.
-    /// Example: "0.05" for 50ms per character.
-    ///
-    /// 打字机速度（每字符秒数）。
-    /// 示例："0.05" 表示每字符50ms。
-    pub const DIALOGUE_TYPEWRITER_SPEED: &str = "dialogue_typewriter_speed";
 }
 
 /// Property definition for validation purposes.
@@ -215,55 +152,6 @@ pub static OBJECT_PROPERTIES: &[PropertyDef] = &[
     PropertyDef {
         key: object_keys::INTERACTABLE,
         description: "Interactable object type",
-        required: false,
-        default: None,
-    },
-    // Dialogue properties
-    PropertyDef {
-        key: object_keys::DIALOGUE_PATH,
-        description: "Path to Mortar dialogue file (relative to locales)",
-        required: false,
-        default: None,
-    },
-    PropertyDef {
-        key: object_keys::DIALOGUE_NODE,
-        description: "Node name in the Mortar file to start dialogue",
-        required: false,
-        default: None,
-    },
-    PropertyDef {
-        key: object_keys::HAS_TYPEWRITER,
-        description: "Whether to use typewriter effect",
-        required: false,
-        default: Some("true"),
-    },
-    PropertyDef {
-        key: object_keys::HAS_MORTAR,
-        description: "Whether to use Mortar controller",
-        required: false,
-        default: Some("true"),
-    },
-    PropertyDef {
-        key: object_keys::SIMPLE_TEXT,
-        description: "Simple text content for non-Mortar dialogue",
-        required: false,
-        default: None,
-    },
-    PropertyDef {
-        key: object_keys::DIALOGUE_VIEW,
-        description: "View layout file for dialogue UI",
-        required: false,
-        default: Some("states/overworld/view/dialogue.view.ron"),
-    },
-    PropertyDef {
-        key: object_keys::DIALOGUE_VOICE,
-        description: "Voice sound effect path for typewriter",
-        required: false,
-        default: None,
-    },
-    PropertyDef {
-        key: object_keys::DIALOGUE_TYPEWRITER_SPEED,
-        description: "Typewriter speed in seconds per character",
         required: false,
         default: None,
     },

--- a/crates/souprune/src/preset/overworld.rs
+++ b/crates/souprune/src/preset/overworld.rs
@@ -202,6 +202,7 @@ fn on_exit_overworld_system(
     registry.clear_local();
     loaded_rule_sets.handles.clear();
     loaded_rule_sets.initialized = false;
+    loaded_rule_sets.registered = false;
 
     info!("Overworld: Cleaned up on exit (BGM + FRE)");
 }

--- a/crates/souprune/src/preset/overworld/collision.rs
+++ b/crates/souprune/src/preset/overworld/collision.rs
@@ -12,7 +12,7 @@ use crate::core::collision::{
     Rect2DCollider, SdfCollisionConfig, collect_nearby_colliders, resolve_sdf_collision,
 };
 use crate::preset::overworld::character::components::PlayerControlled;
-use crate::preset::overworld::tilemap::{ObjectCollider, systems::TilemapCollider};
+use crate::preset::overworld::tilemap::systems::TilemapCollider;
 use bevy::prelude::*;
 
 type PlayerQuery<'w, 's> = Query<
@@ -25,10 +25,7 @@ type TilemapCollidersQuery<'w, 's> = Query<
     'w,
     's,
     (&'static Transform, &'static Rect2DCollider),
-    (
-        Or<(With<TilemapCollider>, With<ObjectCollider>)>,
-        Without<PlayerControlled>,
-    ),
+    (With<TilemapCollider>, Without<PlayerControlled>),
 >;
 
 /// SDF-based collision detection and response system for overworld.

--- a/crates/souprune/src/preset/overworld/tilemap/object_properties.rs
+++ b/crates/souprune/src/preset/overworld/tilemap/object_properties.rs
@@ -131,6 +131,8 @@ pub fn process_map_object_properties_system(
 }
 
 /// Process a single Tiled object, dispatching to the appropriate handler.
+///
+/// 处理单个 Tiled 对象，分发到对应的处理器。
 fn process_tiled_object(
     commands: &mut Commands,
     object_data: &tiled::ObjectData,
@@ -178,6 +180,8 @@ fn process_tiled_object(
 }
 
 /// Parsed object kinds from comma-separated `kind` property.
+///
+/// 从逗号分隔的 `kind` 属性解析出的对象类型集合。
 struct ObjectKinds {
     collision: bool,
     confirm: bool,
@@ -214,6 +218,8 @@ impl ObjectKinds {
 }
 
 /// Dialogue properties extracted from a Tiled object.
+///
+/// 从 Tiled 对象中提取的对话属性。
 struct DialogueProps {
     mortar: String,
     node: String,
@@ -374,6 +380,8 @@ fn spawn_trigger_object(
 }
 
 /// Spawn a collision entity from a Tiled object.
+///
+/// 从 Tiled 对象生成碰撞实体。
 fn spawn_collision_object(
     commands: &mut Commands,
     object_data: &tiled::ObjectData,

--- a/crates/souprune/src/preset/overworld/tilemap/object_properties.rs
+++ b/crates/souprune/src/preset/overworld/tilemap/object_properties.rs
@@ -2,52 +2,52 @@
 //!
 //! ## Module Overview
 //! This module handles custom property detection and processing for Tiled objects.
-//! It provides a flexible system for adding new object property handlers in the future.
+//! It provides a unified trigger system that supports multiple trigger modes
+//! (confirm, enter, exit) and auto-generates FRE rules for dialogue.
 //!
 //! ## 模块概述
-//! 该模块处理Tiled对象的自定义属性检测和处理。
-//! 它为未来添加新的对象属性处理器提供了灵活的系统。
+//! 该模块处理 Tiled 对象的自定义属性检测和处理。
+//! 它提供了统一的触发系统，支持多种触发模式（confirm、enter、exit），
+//! 并为对话自动生成 FRE 规则。
 
 use crate::core::camera::{CameraBoundsZone, TiledCameraBounds};
 use crate::core::collision::Rect2DCollider;
-use crate::core::map_property_schema::{get_object_bool_property, object_keys};
+use crate::core::game_action::{GameActionDef, GameRule, GameRuleRegistry};
+use crate::core::map_property_schema::{
+    get_object_bool_property, get_object_string_property, object_keys,
+};
 use crate::core::mode::ModeScoped;
 use crate::preset::overworld::tilemap::systems::TilemapCollider;
 use crate::preset::overworld::trigger::{Interactable, TriggerZone};
 use bevy::prelude::*;
 use bevy_ecs_tiled::prelude::{TiledMap, TiledMapAsset, tiled};
+use bevy_fact_rule_event::RuleScope;
 
 /// Marker component for objects with collision property
 /// 具有碰撞属性的对象的标记组件
 #[derive(Component)]
 pub struct ObjectCollider;
 
-/// Marker component for trigger zones spawned from Tiled
-/// 从 Tiled 生成的触发区域的标记组件
+/// Marker component for trigger objects spawned from Tiled (unified).
+/// 从 Tiled 生成的触发对象标记组件（统一）。
 #[derive(Component)]
-pub struct TiledTriggerZone;
-
-/// Marker component for interactable objects spawned from Tiled
-/// 从 Tiled 生成的可交互物体的标记组件
-#[derive(Component)]
-pub struct TiledInteractable;
+pub struct TiledTriggerObject;
 
 /// System to process Tiled object layer properties and spawn corresponding entities.
-/// Handles both collision objects and trigger zones.
+/// Handles collision objects, trigger zones, interactables, and auto-generated rules.
 ///
 /// 处理 Tiled 对象层属性并生成相应实体的系统。
-/// 处理碰撞对象和触发区域。
+/// 处理碰撞对象、触发区域、可交互物体和自动生成的规则。
 #[allow(dead_code)]
 pub fn process_map_object_properties_system(
     mut commands: Commands,
     tiled_map_assets: Res<Assets<TiledMapAsset>>,
     tiled_maps_query: Query<&TiledMap>,
-    existing_triggers: Query<&TiledTriggerZone>,
-    existing_interactables: Query<&TiledInteractable>,
+    existing_triggers: Query<&TiledTriggerObject>,
     loaded_rule_sets: Res<crate::preset::overworld::trigger::LoadedRuleSets>,
+    mut registry: ResMut<GameRuleRegistry>,
 ) {
-    // Process once per map load cycle (reset when LoadedRuleSets resets)
-    if !existing_triggers.is_empty() || !existing_interactables.is_empty() {
+    if !existing_triggers.is_empty() {
         return;
     }
     if !loaded_rule_sets.initialized {
@@ -55,13 +55,10 @@ pub fn process_map_object_properties_system(
     }
 
     let map_count = tiled_maps_query.iter().count();
-
-    // Wait for map to be available
     if map_count == 0 {
         return;
     }
 
-    // Try to get map asset - if not loaded yet, wait
     let mut any_map_loaded = false;
     for tiled_map_handle in tiled_maps_query.iter() {
         if tiled_map_assets.get(&tiled_map_handle.0).is_some() {
@@ -81,9 +78,8 @@ pub fn process_map_object_properties_system(
             continue;
         };
 
-        info!("Processing tiled map for triggers and interactables");
+        info!("Processing tiled map for trigger objects");
 
-        // Calculate map center offset (Tiled uses top-left origin, Bevy uses center)
         let tile_width = tiled_map_asset.map.tile_width as f32;
         let tile_height = tiled_map_asset.map.tile_height as f32;
         let map_width = tiled_map_asset.map.width as f32 * tile_width;
@@ -102,7 +98,6 @@ pub fn process_map_object_properties_system(
                 object_layer.objects().count()
             );
 
-            // A layer named "camera_bounds" treats all objects as camera zones.
             if layer.name == object_keys::CAMERA_BOUNDS {
                 spawn_camera_bounds_from_layer(
                     &mut commands,
@@ -121,11 +116,11 @@ pub fn process_map_object_properties_system(
                     center_offset_x,
                     center_offset_y,
                     map_height,
+                    &mut registry,
                 );
             }
         }
 
-        // Process only the first map for now
         break;
     }
 
@@ -139,6 +134,7 @@ fn process_tiled_object(
     center_offset_x: f32,
     center_offset_y: f32,
     map_height: f32,
+    registry: &mut GameRuleRegistry,
 ) {
     trace!(
         "Checking object '{}' at ({}, {}) with shape {:?}",
@@ -157,38 +153,209 @@ fn process_tiled_object(
         return;
     }
 
-    // Collision objects are handled by generate_collision_tiles_system
-    if get_object_bool_property(&object_data.properties, object_keys::COLLISION) == Some(true) {
-        return;
+    // Unified object kinds (collision, trigger, etc.)
+    if let Some(kind_str) = get_object_string_property(&object_data.properties, object_keys::KIND) {
+        let kinds = ObjectKinds::parse(kind_str);
+
+        // Collision is handled by generate_collision_tiles_system
+        if kinds.has_trigger() {
+            spawn_trigger_object(
+                commands,
+                object_data,
+                center_offset_x,
+                center_offset_y,
+                map_height,
+                &kinds,
+                registry,
+            );
+        }
+    }
+}
+
+/// Parsed object kinds from comma-separated `kind` property.
+struct ObjectKinds {
+    collision: bool,
+    confirm: bool,
+    enter: bool,
+    exit: bool,
+}
+
+impl ObjectKinds {
+    fn parse(kind_str: &str) -> Self {
+        let mut kinds = Self {
+            collision: false,
+            confirm: false,
+            enter: false,
+            exit: false,
+        };
+        for part in kind_str.split(',') {
+            match part.trim() {
+                "collision" => kinds.collision = true,
+                "confirm" => kinds.confirm = true,
+                "enter" => kinds.enter = true,
+                "exit" => kinds.exit = true,
+                other => warn!(
+                    "Unknown object kind '{}', expected collision/confirm/enter/exit",
+                    other
+                ),
+            }
+        }
+        kinds
     }
 
-    // Handle trigger zones
-    if get_object_bool_property(&object_data.properties, object_keys::TRIGGER) == Some(true) {
-        spawn_trigger_zone(
-            commands,
-            object_data,
-            center_offset_x,
-            center_offset_y,
-            map_height,
-        );
-        return;
+    fn has_trigger(&self) -> bool {
+        self.confirm || self.enter || self.exit
+    }
+}
+
+/// Dialogue properties extracted from a Tiled object.
+struct DialogueProps {
+    mortar: String,
+    node: String,
+    view: Option<String>,
+    typewriter: bool,
+    focus: bool,
+    voice: Option<String>,
+}
+
+impl DialogueProps {
+    fn from_object(object_data: &tiled::ObjectData) -> Option<Self> {
+        let mortar = get_object_string_property(&object_data.properties, object_keys::MORTAR)?;
+
+        let node = get_object_string_property(&object_data.properties, object_keys::MORTAR_NODE)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| object_data.name.clone());
+
+        let view = get_object_string_property(&object_data.properties, object_keys::VIEW)
+            .map(|s| s.to_string());
+
+        let typewriter = get_object_bool_property(&object_data.properties, object_keys::TYPEWRITER)
+            .unwrap_or(true);
+
+        let focus =
+            get_object_bool_property(&object_data.properties, object_keys::FOCUS).unwrap_or(true);
+
+        let voice = get_object_string_property(&object_data.properties, object_keys::VOICE)
+            .map(|s| s.to_string());
+
+        Some(Self {
+            mortar: mortar.to_string(),
+            node,
+            view,
+            typewriter,
+            focus,
+            voice,
+        })
     }
 
-    // Handle interactable objects
-    let is_interactable =
-        get_object_bool_property(&object_data.properties, object_keys::INTERACTABLE);
+    fn to_action(&self) -> GameActionDef {
+        GameActionDef::StartDialogue {
+            mortar: self.mortar.clone(),
+            node: self.node.clone(),
+            view: self.view.clone(),
+            typewriter: self.typewriter,
+            focus: self.focus,
+            voice: self.voice.clone(),
+        }
+    }
+}
+
+/// Spawn a unified trigger object from Tiled properties.
+///
+/// Parses trigger modes (confirm, enter, exit), attaches the appropriate
+/// components, and auto-generates StartDialogue FRE rules if dialogue
+/// properties are present.
+///
+/// 从 Tiled 属性生成统一触发对象。
+///
+/// 解析触发模式（confirm、enter、exit），挂载相应组件，
+/// 如果存在对话属性则自动生成 StartDialogue FRE 规则。
+fn spawn_trigger_object(
+    commands: &mut Commands,
+    object_data: &tiled::ObjectData,
+    center_offset_x: f32,
+    center_offset_y: f32,
+    map_height: f32,
+    kinds: &ObjectKinds,
+    registry: &mut GameRuleRegistry,
+) {
+    let tiled::ObjectShape::Rect { width, height } = object_data.shape else {
+        trace!("Trigger object '{}' is not a rectangle", object_data.name);
+        return;
+    };
+
+    let object_id = if !object_data.name.is_empty() {
+        object_data.name.clone()
+    } else {
+        format!("trigger_{}", object_data.id())
+    };
+
+    let world_x = center_offset_x + object_data.x + width / 2.0;
+    let world_y = center_offset_y + (map_height - object_data.y - height / 2.0);
+    let size = Vec2::new(width, height);
+
     info!(
-        "Object '{}' interactable property: {:?}",
-        object_data.name, is_interactable
+        "FRE: Creating trigger object '{}' at ({:.1}, {:.1}) size ({}, {})",
+        object_id, world_x, world_y, width, height
     );
-    if is_interactable == Some(true) {
-        spawn_interactable(
-            commands,
-            object_data,
-            center_offset_x,
-            center_offset_y,
-            map_height,
-        );
+
+    let mut entity_cmd = commands.spawn((
+        ModeScoped("overworld".to_string()),
+        TiledTriggerObject,
+        Rect2DCollider::new(size, Vec2::ZERO),
+        Transform::from_xyz(world_x, world_y, 0.0),
+        Visibility::Hidden,
+        Name::new(format!("TriggerObject_{}", object_id)),
+    ));
+
+    if kinds.enter || kinds.exit {
+        entity_cmd.insert(TriggerZone::new(&object_id));
+    }
+
+    if kinds.confirm {
+        entity_cmd.insert(Interactable::new(&object_id));
+    }
+
+    // Auto-generate dialogue rules from Tiled properties
+    let dialogue_props = DialogueProps::from_object(object_data);
+    if let Some(props) = &dialogue_props {
+        let action = props.to_action();
+
+        if kinds.confirm {
+            let rule_id = format!("auto_interact_{}", object_id);
+            let event_id = format!("interact_{}", object_id);
+            let rule = GameRule::builder(rule_id, event_id)
+                .scope(RuleScope::Local)
+                .priority(-100)
+                .action(action.clone())
+                .build();
+            registry.register(rule);
+            info!("FRE: Auto-generated confirm rule for '{}'", object_id);
+        }
+
+        if kinds.enter {
+            let rule_id = format!("auto_trigger_enter_{}", object_id);
+            let event_id = format!("trigger_enter_{}", object_id);
+            let rule = GameRule::builder(rule_id, event_id)
+                .scope(RuleScope::Local)
+                .priority(-100)
+                .action(action.clone())
+                .build();
+            registry.register(rule);
+            info!("FRE: Auto-generated enter rule for '{}'", object_id);
+        }
+
+        if kinds.exit {
+            let rule_id = format!("auto_trigger_exit_{}", object_id);
+            let event_id = format!("trigger_exit_{}", object_id);
+            let rule = GameRule::builder(rule_id, event_id)
+                .scope(RuleScope::Local)
+                .priority(-100)
+                .action(action)
+                .build();
+            registry.register(rule);
+            info!("FRE: Auto-generated exit rule for '{}'", object_id);
+        }
     }
 }
 
@@ -205,7 +372,6 @@ fn spawn_collision_object(
         return;
     };
 
-    // Convert Tiled coordinates (top-left origin) to Bevy (center-based)
     let world_x = center_offset_x + object_data.x + width / 2.0;
     let world_y = center_offset_y + (map_height - object_data.y - height / 2.0);
     let size = Vec2::new(width, height);
@@ -264,11 +430,9 @@ fn spawn_camera_bounds_zone(
         return;
     };
 
-    // Convert Tiled coordinates (top-left origin) to Bevy world space (center-based)
     let world_x = center_offset_x + object_data.x + width / 2.0;
     let world_y = center_offset_y + (map_height - object_data.y - height / 2.0);
 
-    // Build the zone rect in world space (min/max corners)
     let half_w = width / 2.0;
     let half_h = height / 2.0;
     let rect = bevy::math::Rect::new(
@@ -294,93 +458,5 @@ fn spawn_camera_bounds_zone(
         TiledCameraBounds,
         CameraBoundsZone { rect },
         Name::new(format!("CameraBounds_{}", zone_name)),
-    ));
-}
-
-/// Spawn a trigger zone entity from a Tiled object.
-fn spawn_trigger_zone(
-    commands: &mut Commands,
-    object_data: &tiled::ObjectData,
-    center_offset_x: f32,
-    center_offset_y: f32,
-    map_height: f32,
-) {
-    let tiled::ObjectShape::Rect { width, height } = object_data.shape else {
-        trace!("Trigger object '{}' is not a rectangle", object_data.name);
-        return;
-    };
-
-    // Use object name if provided, otherwise use Tiled object ID
-    let trigger_id = if !object_data.name.is_empty() {
-        object_data.name.clone()
-    } else {
-        format!("trigger_{}", object_data.id())
-    };
-
-    // Convert Tiled coordinates (top-left origin) to Bevy (center-based)
-    let world_x = center_offset_x + object_data.x + width / 2.0;
-    let world_y = center_offset_y + (map_height - object_data.y - height / 2.0);
-    let size = Vec2::new(width, height);
-
-    info!(
-        "FRE: Creating trigger zone '{}' at ({:.1}, {:.1}) size ({}, {})",
-        trigger_id, world_x, world_y, width, height
-    );
-
-    commands.spawn((
-        ModeScoped("overworld".to_string()),
-        TiledTriggerZone,
-        TriggerZone::new(&trigger_id),
-        Rect2DCollider::new(size, Vec2::ZERO),
-        Transform::from_xyz(world_x, world_y, 0.0),
-        Visibility::Hidden,
-        Name::new(format!("TriggerZone_{}", trigger_id)),
-    ));
-}
-
-/// Spawn an interactable entity from a Tiled object.
-/// Interaction behavior is defined in FRE rule files (via `rules_file` map property).
-///
-/// 从 Tiled 对象生成可交互实体。
-/// 交互行为通过 FRE 规则文件定义（通过地图属性 `rules_file`）。
-fn spawn_interactable(
-    commands: &mut Commands,
-    object_data: &tiled::ObjectData,
-    center_offset_x: f32,
-    center_offset_y: f32,
-    map_height: f32,
-) {
-    let tiled::ObjectShape::Rect { width, height } = object_data.shape else {
-        trace!(
-            "Interactable object '{}' is not a rectangle",
-            object_data.name
-        );
-        return;
-    };
-
-    let interactable_id = if !object_data.name.is_empty() {
-        object_data.name.clone()
-    } else {
-        format!("interactable_{}", object_data.id())
-    };
-
-    // Convert Tiled coordinates (top-left origin) to Bevy (center-based)
-    let world_x = center_offset_x + object_data.x + width / 2.0;
-    let world_y = center_offset_y + (map_height - object_data.y - height / 2.0);
-    let size = Vec2::new(width, height);
-
-    info!(
-        "FRE: Creating interactable '{}' at ({:.1}, {:.1}) size ({}, {})",
-        interactable_id, world_x, world_y, width, height
-    );
-
-    commands.spawn((
-        ModeScoped("overworld".to_string()),
-        TiledInteractable,
-        Interactable::new(&interactable_id),
-        Rect2DCollider::new(size, Vec2::ZERO),
-        Transform::from_xyz(world_x, world_y, 0.0),
-        Visibility::Hidden,
-        Name::new(format!("Interactable_{}", interactable_id)),
     ));
 }

--- a/crates/souprune/src/preset/overworld/tilemap/object_properties.rs
+++ b/crates/souprune/src/preset/overworld/tilemap/object_properties.rs
@@ -10,19 +10,12 @@
 
 use crate::core::camera::{CameraBoundsZone, TiledCameraBounds};
 use crate::core::collision::Rect2DCollider;
-use crate::core::fre_facts;
-use crate::core::map_property_schema::{
-    escape_property_string, get_object_bool_property, get_object_float_property,
-    get_string_property, object_keys,
-};
+use crate::core::map_property_schema::{get_object_bool_property, object_keys};
 use crate::core::mode::ModeScoped;
 use crate::preset::overworld::tilemap::systems::TilemapCollider;
 use crate::preset::overworld::trigger::{Interactable, TriggerZone};
 use bevy::prelude::*;
 use bevy_ecs_tiled::prelude::{TiledMap, TiledMapAsset, tiled};
-use bevy_fact_rule_event::{FactModification, FactValue, Rule, RuleScope};
-
-use crate::core::game_action::GameRuleRegistry;
 
 /// Marker component for objects with collision property
 /// 具有碰撞属性的对象的标记组件
@@ -51,8 +44,6 @@ pub fn process_map_object_properties_system(
     tiled_maps_query: Query<&TiledMap>,
     existing_triggers: Query<&TiledTriggerZone>,
     existing_interactables: Query<&TiledInteractable>,
-    mut rule_registry: ResMut<GameRuleRegistry>,
-    souprune_config: Res<crate::config::SoupruneConfig>,
     loaded_rule_sets: Res<crate::preset::overworld::trigger::LoadedRuleSets>,
 ) {
     // Process once per map load cycle (reset when LoadedRuleSets resets)
@@ -130,8 +121,6 @@ pub fn process_map_object_properties_system(
                     center_offset_x,
                     center_offset_y,
                     map_height,
-                    &mut rule_registry,
-                    &souprune_config.game.dialogue_view_default,
                 );
             }
         }
@@ -150,8 +139,6 @@ fn process_tiled_object(
     center_offset_x: f32,
     center_offset_y: f32,
     map_height: f32,
-    rule_registry: &mut GameRuleRegistry,
-    dialogue_view_default: &str,
 ) {
     trace!(
         "Checking object '{}' at ({}, {}) with shape {:?}",
@@ -201,8 +188,6 @@ fn process_tiled_object(
             center_offset_x,
             center_offset_y,
             map_height,
-            rule_registry,
-            dialogue_view_default,
         );
     }
 }
@@ -354,18 +339,16 @@ fn spawn_trigger_zone(
 }
 
 /// Spawn an interactable entity from a Tiled object.
-/// If dialogue properties are set, also registers an FRE rule for handling interaction.
+/// Interaction behavior is defined in FRE rule files (via `rules_file` map property).
 ///
 /// 从 Tiled 对象生成可交互实体。
-/// 如果设置了对话属性，也注册 FRE 规则处理交互。
+/// 交互行为通过 FRE 规则文件定义（通过地图属性 `rules_file`）。
 fn spawn_interactable(
     commands: &mut Commands,
     object_data: &tiled::ObjectData,
     center_offset_x: f32,
     center_offset_y: f32,
     map_height: f32,
-    rule_registry: &mut GameRuleRegistry,
-    dialogue_view_default: &str,
 ) {
     let tiled::ObjectShape::Rect { width, height } = object_data.shape else {
         trace!(
@@ -375,7 +358,6 @@ fn spawn_interactable(
         return;
     };
 
-    // Use object name if provided, otherwise use Tiled object ID
     let interactable_id = if !object_data.name.is_empty() {
         object_data.name.clone()
     } else {
@@ -387,143 +369,15 @@ fn spawn_interactable(
     let world_y = center_offset_y + (map_height - object_data.y - height / 2.0);
     let size = Vec2::new(width, height);
 
-    // Read dialogue configuration from object properties
-    // 从对象属性读取对话配置
-    let dialogue_path =
-        get_string_property(&object_data.properties, object_keys::DIALOGUE_PATH).map(String::from);
-    let dialogue_node =
-        get_string_property(&object_data.properties, object_keys::DIALOGUE_NODE).map(String::from);
-    let has_typewriter =
-        get_object_bool_property(&object_data.properties, object_keys::HAS_TYPEWRITER)
-            .unwrap_or(true);
-    let has_mortar =
-        get_object_bool_property(&object_data.properties, object_keys::HAS_MORTAR).unwrap_or(true);
-    let simple_text =
-        get_string_property(&object_data.properties, object_keys::SIMPLE_TEXT).map(String::from);
-    let dialogue_view = get_string_property(&object_data.properties, object_keys::DIALOGUE_VIEW)
-        .map(String::from)
-        .unwrap_or_else(|| dialogue_view_default.to_string());
-    let dialogue_voice =
-        get_string_property(&object_data.properties, object_keys::DIALOGUE_VOICE).map(String::from);
-    let dialogue_typewriter_speed = get_object_float_property(
-        &object_data.properties,
-        object_keys::DIALOGUE_TYPEWRITER_SPEED,
-    );
-
-    // Check if dialogue is configured
-    let has_dialogue = dialogue_path.is_some() || simple_text.is_some();
-
     info!(
-        "FRE: Creating interactable '{}' at ({:.1}, {:.1}) size ({}, {}), dialogue: {}",
-        interactable_id, world_x, world_y, width, height, has_dialogue
+        "FRE: Creating interactable '{}' at ({:.1}, {:.1}) size ({}, {})",
+        interactable_id, world_x, world_y, width, height
     );
-
-    // If dialogue is configured, create FRE rule for handling interaction
-    // 如果配置了对话，创建 FRE 规则处理交互
-    if has_dialogue {
-        let trigger_event = format!("interact_{}", interactable_id);
-        let rule_id = format!("dialogue_interact_{}", interactable_id);
-
-        // Build modifications for the rule
-        // 为规则构建 modifications
-        let mut modifications = vec![
-            // Set typewriter flag
-            FactModification::Set(
-                fre_facts::DIALOGUE_HAS_TYPEWRITER.to_string(),
-                FactValue::Bool(has_typewriter),
-            ),
-            // Set view path
-            FactModification::Set(
-                fre_facts::DIALOGUE_PENDING_VIEW.to_string(),
-                FactValue::String(dialogue_view),
-            ),
-            // Set focus flag (default true for interactive dialogues)
-            // 设置焦点标志（交互对话默认为 true）
-            FactModification::Set(
-                fre_facts::DIALOGUE_HAS_FOCUS.to_string(),
-                FactValue::Bool(true),
-            ),
-        ];
-
-        // Add voice sound effect if configured
-        // 添加音效（如果配置了）
-        if let Some(voice) = dialogue_voice {
-            modifications.push(FactModification::Set(
-                fre_facts::DIALOGUE_VOICE.to_string(),
-                FactValue::String(voice),
-            ));
-        }
-
-        // Add typewriter speed if configured
-        // 添加打字机速度（如果配置了）
-        if let Some(speed) = dialogue_typewriter_speed {
-            modifications.push(FactModification::Set(
-                fre_facts::DIALOGUE_TYPEWRITER_SPEED.to_string(),
-                FactValue::Float(speed),
-            ));
-        }
-
-        // Add Mortar path and node if using Mortar
-        if has_mortar {
-            if let Some(path) = dialogue_path {
-                modifications.push(FactModification::Set(
-                    fre_facts::DIALOGUE_PENDING_MORTAR_PATH.to_string(),
-                    FactValue::String(path),
-                ));
-            }
-            if let Some(node) = dialogue_node {
-                modifications.push(FactModification::Set(
-                    fre_facts::DIALOGUE_PENDING_MORTAR_NODE.to_string(),
-                    FactValue::String(node),
-                ));
-            }
-        }
-
-        // Add simple text if not using Mortar
-        if !has_mortar {
-            modifications.push(FactModification::Set(
-                fre_facts::DIALOGUE_SIMPLE_TEXT_ACTIVE.to_string(),
-                FactValue::Bool(true),
-            ));
-            if let Some(text) = simple_text {
-                let escaped_text = escape_property_string(text);
-                modifications.push(FactModification::Set(
-                    fre_facts::DIALOGUE_SIMPLE_TEXT.to_string(),
-                    FactValue::String(escaped_text),
-                ));
-            }
-        }
-
-        // Add trigger to start dialogue (must be last to ensure all other facts are set first)
-        // 添加触发器启动对话（必须最后设置，以确保其他 facts 已设置）
-        modifications.push(FactModification::Set(
-            fre_facts::DIALOGUE_PENDING_START.to_string(),
-            FactValue::Bool(true),
-        ));
-
-        // Build and register the rule (Local scope - cleared when leaving Overworld)
-        // 构建并注册规则（Local 作用域 - 离开 Overworld 时清除）
-        let mut rule_builder =
-            Rule::builder(&rule_id, trigger_event.clone()).scope(RuleScope::Local);
-        for modification in modifications {
-            rule_builder = rule_builder.modify(modification);
-        }
-        let rule = rule_builder.build();
-
-        rule_registry.register(rule);
-        info!(
-            "FRE: Registered dialogue rule '{}' for trigger '{}'",
-            rule_id, trigger_event
-        );
-    }
-
-    // Spawn interactable entity (without dialogue_config)
-    let interactable = Interactable::new(&interactable_id);
 
     commands.spawn((
         ModeScoped("overworld".to_string()),
         TiledInteractable,
-        interactable,
+        Interactable::new(&interactable_id),
         Rect2DCollider::new(size, Vec2::ZERO),
         Transform::from_xyz(world_x, world_y, 0.0),
         Visibility::Hidden,

--- a/crates/souprune/src/preset/overworld/tilemap/object_properties.rs
+++ b/crates/souprune/src/preset/overworld/tilemap/object_properties.rs
@@ -10,6 +10,7 @@
 //! 它提供了统一的触发系统，支持多种触发模式（confirm、enter、exit），
 //! 并为对话自动生成 FRE 规则。
 
+use crate::config::SoupruneConfig;
 use crate::core::camera::{CameraBoundsZone, TiledCameraBounds};
 use crate::core::collision::Rect2DCollider;
 use crate::core::game_action::{GameActionDef, GameRule, GameRuleRegistry};
@@ -46,6 +47,7 @@ pub fn process_map_object_properties_system(
     existing_triggers: Query<&TiledTriggerObject>,
     loaded_rule_sets: Res<crate::preset::overworld::trigger::LoadedRuleSets>,
     mut registry: ResMut<GameRuleRegistry>,
+    config: Res<SoupruneConfig>,
 ) {
     if !existing_triggers.is_empty() {
         return;
@@ -117,6 +119,7 @@ pub fn process_map_object_properties_system(
                     center_offset_y,
                     map_height,
                     &mut registry,
+                    &config,
                 );
             }
         }
@@ -135,6 +138,7 @@ fn process_tiled_object(
     center_offset_y: f32,
     map_height: f32,
     registry: &mut GameRuleRegistry,
+    config: &SoupruneConfig,
 ) {
     trace!(
         "Checking object '{}' at ({}, {}) with shape {:?}",
@@ -167,6 +171,7 @@ fn process_tiled_object(
                 map_height,
                 &kinds,
                 registry,
+                config,
             );
         }
     }
@@ -219,7 +224,7 @@ struct DialogueProps {
 }
 
 impl DialogueProps {
-    fn from_object(object_data: &tiled::ObjectData) -> Option<Self> {
+    fn from_object(object_data: &tiled::ObjectData, default_view: &str) -> Option<Self> {
         let mortar = get_object_string_property(&object_data.properties, object_keys::MORTAR)?;
 
         let node = get_object_string_property(&object_data.properties, object_keys::MORTAR_NODE)
@@ -227,7 +232,14 @@ impl DialogueProps {
             .unwrap_or_else(|| object_data.name.clone());
 
         let view = get_object_string_property(&object_data.properties, object_keys::VIEW)
-            .map(|s| s.to_string());
+            .map(|s| s.to_string())
+            .or_else(|| {
+                if default_view.is_empty() {
+                    None
+                } else {
+                    Some(default_view.to_string())
+                }
+            });
 
         let typewriter = get_object_bool_property(&object_data.properties, object_keys::TYPEWRITER)
             .unwrap_or(true);
@@ -278,6 +290,7 @@ fn spawn_trigger_object(
     map_height: f32,
     kinds: &ObjectKinds,
     registry: &mut GameRuleRegistry,
+    config: &SoupruneConfig,
 ) {
     let tiled::ObjectShape::Rect { width, height } = object_data.shape else {
         trace!("Trigger object '{}' is not a rectangle", object_data.name);
@@ -317,7 +330,8 @@ fn spawn_trigger_object(
     }
 
     // Auto-generate dialogue rules from Tiled properties
-    let dialogue_props = DialogueProps::from_object(object_data);
+    let dialogue_props =
+        DialogueProps::from_object(object_data, &config.game.dialogue_view_default);
     if let Some(props) = &dialogue_props {
         let action = props.to_action();
 

--- a/crates/souprune/src/preset/overworld/tilemap/systems.rs
+++ b/crates/souprune/src/preset/overworld/tilemap/systems.rs
@@ -345,12 +345,14 @@ fn generate_object_colliders(
 
             let size = Vec2::new(width, height);
 
-            // Check if this object has collision property set to true (using schema key constant)
-            if crate::core::map_property_schema::get_object_bool_property(
+            // Check if this object has collision kind (using schema key constant)
+            let has_collision = crate::core::map_property_schema::get_object_string_property(
                 &object_data.properties,
-                object_keys::COLLISION,
-            ) == Some(true)
-            {
+                object_keys::KIND,
+            )
+            .is_some_and(|s| s.split(',').any(|p| p.trim() == "collision"));
+
+            if has_collision {
                 info!(
                     "Creating collision object '{}' at world pos ({}, {}) with size ({}, {})",
                     object_data.name, world_x, world_y, width, height
@@ -364,37 +366,6 @@ fn generate_object_colliders(
                     Transform::from_xyz(world_x, world_y, 0.0),
                     Visibility::Hidden,
                     Name::new(format!("ObjectCollision_{}", object_data.name)),
-                ));
-            }
-
-            // Check if this object has trigger property set to true (experimental feature)
-            #[cfg(feature = "experimental")]
-            if crate::core::map_property_schema::get_object_bool_property(
-                &object_data.properties,
-                object_keys::TRIGGER,
-            ) == Some(true)
-            {
-                // Get trigger ID from name or id property (using schema key constant)
-                let trigger_id = crate::core::map_property_schema::get_object_string_property(
-                    &object_data.properties,
-                    object_keys::TRIGGER_ID,
-                )
-                .map(|s| s.to_string())
-                .or_else(|| (!object_data.name.is_empty()).then(|| object_data.name.clone()))
-                .unwrap_or_else(|| format!("trigger_{}", object_data.id()));
-
-                info!(
-                    "Creating trigger zone '{}' at world pos ({}, {}) with size ({}, {})",
-                    trigger_id, world_x, world_y, width, height
-                );
-
-                commands.spawn((
-                    ChildOf(parent_entity),
-                    crate::preset::overworld::trigger::TriggerZone::new(&trigger_id),
-                    Rect2DCollider::new(size, Vec2::ZERO),
-                    Transform::from_xyz(world_x, world_y, 0.0),
-                    Visibility::Hidden,
-                    Name::new(format!("TriggerZone_{}", trigger_id)),
                 ));
             }
         }

--- a/crates/souprune/src/preset/overworld/trigger.rs
+++ b/crates/souprune/src/preset/overworld/trigger.rs
@@ -132,7 +132,7 @@ pub fn trigger_zone_detection_system(
     }
 }
 
-/// System to load FRE rules from map's `rules_file` property.
+/// System to load FRE rules from map's `rules_file` property and dependency chain.
 pub fn load_fre_rules_system(
     asset_server: Res<AssetServer>,
     mut loaded_rule_sets: ResMut<LoadedRuleSets>,
@@ -143,6 +143,18 @@ pub fn load_fre_rules_system(
         return;
     }
 
+    // Load overworld rules from dependency chain (preset rules)
+    let config = crate::config::load_config();
+    for rules_path in &config.game.overworld_rules {
+        let handle: Handle<GameFreAsset> = asset_server.load(rules_path);
+        loaded_rule_sets.handles.push(handle);
+        info!(
+            "FRE: Loading overworld rules from dependency chain: {}",
+            rules_path
+        );
+    }
+
+    // Load per-map rules from the map's rules_file property
     for tiled_map in tiled_maps.iter() {
         if let Some(map_asset) = tiled_map_assets.get(&tiled_map.0)
             && let Some(rules_path) =

--- a/crates/souprune/src/preset/overworld/trigger.rs
+++ b/crates/souprune/src/preset/overworld/trigger.rs
@@ -123,6 +123,11 @@ pub fn trigger_zone_detection_system(
         } else if !overlap && trigger.player_inside {
             trigger.player_inside = false;
             info!("FRE: Player exited trigger zone '{}'", trigger.id);
+            let exit_event = format!("trigger_exit_{}", trigger.id);
+            event_writer.write(
+                FactEvent::with_entity(exit_event, player_entity)
+                    .with_data("trigger_id", &trigger.id),
+            );
         }
     }
 }

--- a/crates/souprune/src/preset/overworld/trigger/action_handlers.rs
+++ b/crates/souprune/src/preset/overworld/trigger/action_handlers.rs
@@ -16,6 +16,12 @@
 use super::*;
 use crate::core::danmaku::PlayPerformanceEvent;
 use crate::core::game_action::{GameActionDef, GameActionHandlerRegistry};
+use crate::core::sequencer::chapter_schema::Chapter;
+use crate::core::sequencer::context::SequenceContext;
+use crate::preset::overworld::tilemap::object_properties::ObjectCollider;
+use crate::preset::overworld::tilemap::systems::TilemapCollider;
+use bevy_ecs_tiled::prelude::{TiledName, TiledObjectVisualOf};
+use std::collections::HashMap;
 
 /// Resource to store pending danmaku play requests from FRE actions.
 #[derive(Resource, Default)]
@@ -163,6 +169,135 @@ pub fn setup_action_handlers_system(world: &mut World) {
         });
     });
 
+    handler_registry.register("RunSequence", |action, _db, commands| {
+        let GameActionDef::Custom { params, .. } = action else {
+            return;
+        };
+        let Some(path) = params.get("path").cloned() else {
+            warn!("FRE: RunSequence action missing 'path' param");
+            return;
+        };
+        info!("FRE: RunSequence '{}' via registered handler", path);
+        commands.queue(move |world: &mut World| {
+            let mut context = world.resource_mut::<SequenceContext>();
+            context.chapters.insert(
+                0,
+                Chapter::RunSequence {
+                    path: Some(path),
+                    path_fact: None,
+                    params: HashMap::new(),
+                },
+            );
+        });
+    });
+
+    handler_registry.register("SetSprite", |action, _db, commands| {
+        let GameActionDef::Custom { params, .. } = action else {
+            return;
+        };
+        let Some(target) = params.get("target").cloned() else {
+            warn!("FRE: SetSprite action missing 'target' param");
+            return;
+        };
+        let Some(image_path) = params.get("image").cloned() else {
+            warn!("FRE: SetSprite action missing 'image' param");
+            return;
+        };
+        info!(
+            "FRE: SetSprite target='{}' image='{}' via registered handler",
+            target, image_path
+        );
+        commands.queue(move |world: &mut World| {
+            // Find TiledObject entity by TiledName
+            let object_entity = {
+                let mut query = world.query::<(Entity, &TiledName)>();
+                query
+                    .iter(world)
+                    .find(|(_, name)| name.0 == target)
+                    .map(|(e, _)| e)
+            };
+            let Some(object_entity) = object_entity else {
+                warn!("FRE: SetSprite could not find TiledName '{}'", target);
+                return;
+            };
+
+            // Find child visual entity via TiledObjectVisualOf
+            let visual_entity = {
+                let mut query = world.query::<(Entity, &TiledObjectVisualOf)>();
+                query
+                    .iter(world)
+                    .find(|(_, vis_of)| vis_of.0 == object_entity)
+                    .map(|(e, _)| e)
+            };
+            let Some(visual_entity) = visual_entity else {
+                warn!(
+                    "FRE: SetSprite could not find TiledObjectVisualOf for '{}'",
+                    target
+                );
+                return;
+            };
+
+            // Load new image and update sprite
+            let new_handle = world.resource::<AssetServer>().load::<Image>(&image_path);
+            if let Some(mut sprite) = world.get_mut::<Sprite>(visual_entity) {
+                sprite.image = new_handle;
+                info!("FRE: SetSprite updated sprite for '{}'", target);
+            } else {
+                warn!(
+                    "FRE: SetSprite visual entity for '{}' has no Sprite component",
+                    target
+                );
+            }
+        });
+    });
+
+    handler_registry.register("SetCollision", |action, _db, commands| {
+        let GameActionDef::Custom { params, .. } = action else {
+            return;
+        };
+        let Some(target) = params.get("target").cloned() else {
+            warn!("FRE: SetCollision action missing 'target' param");
+            return;
+        };
+        let Some(enabled_str) = params.get("isEnabled").cloned() else {
+            warn!("FRE: SetCollision action missing 'isEnabled' param");
+            return;
+        };
+        let is_enabled = enabled_str == "true";
+        info!(
+            "FRE: SetCollision target='{}' isEnabled={} via registered handler",
+            target, is_enabled
+        );
+        commands.queue(move |world: &mut World| {
+            let collision_name = format!("ObjectCollision_{}", target);
+            let collision_entity = {
+                let mut query = world.query::<(Entity, &Name, &ObjectCollider)>();
+                query
+                    .iter(world)
+                    .find(|(_, name, _)| name.as_str() == collision_name)
+                    .map(|(e, _, _)| e)
+            };
+            let Some(collision_entity) = collision_entity else {
+                warn!(
+                    "FRE: SetCollision could not find collision entity '{}'",
+                    collision_name
+                );
+                return;
+            };
+
+            let has_collider = world.get::<TilemapCollider>(collision_entity).is_some();
+            if is_enabled && !has_collider {
+                world.entity_mut(collision_entity).insert(TilemapCollider);
+                info!("FRE: SetCollision enabled collision for '{}'", target);
+            } else if !is_enabled && has_collider {
+                world
+                    .entity_mut(collision_entity)
+                    .remove::<TilemapCollider>();
+                info!("FRE: SetCollision disabled collision for '{}'", target);
+            }
+        });
+    });
+
     handler_registry.register("SetPlayerHP", |action, _db, _commands| {
         if let GameActionDef::Custom { params, .. } = action
             && let Some(value_str) = params.get("value")
@@ -172,7 +307,7 @@ pub fn setup_action_handlers_system(world: &mut World) {
         }
     });
 
-    info!("FRE: Overworld action handlers registered (8 handlers)");
+    info!("FRE: Overworld action handlers registered (11 handlers)");
 }
 
 /// System that handles unregistered Custom FRE actions.


### PR DESCRIPTION
### PR Type

*Please check the type of this PR (you can select multiple)*

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation change
- [ ] 🎨 Code style change (such as formatting, renaming)
- [x] ♻️ Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🧪 Adding or updating tests
- [ ] 🤖 CI/CD (Changes to CI/CD configuration)
- [ ] 📦 Other changes

### Breaking Change?

- [x] ⚠️ This PR introduces a breaking change

### Related Issue

N/A

### What does this PR do?

This PR implements a unified trigger and dialogue system for the overworld, replacing the previous dual-concept approach (`trigger`+`trigger_id` and `interactable`) with a single, data-driven system. It also fixes several bugs discovered during integration testing.

**Trigger System Unification:**
- Replaced separate `trigger_id`/`interactable` Tiled properties with a unified `kind` property that supports comma-separated modes: `confirm`, `enter`, `exit`, `collision`.
- Merged `spawn_trigger_zone()` and `spawn_interactable()` into a single `spawn_trigger_object()` function.
- Simplified `map_property_schema.rs` by removing deprecated schema constants (`TRIGGER_ID`, `INTERACTABLE`) and adding new ones (`MORTAR`, `MORTAR_NODE`, `TYPEWRITER`, `VOICE`, `VIEW`).

**Auto-generated Dialogue Rules:**
- Tiled objects with `mortar` property now auto-generate `StartDialogue` FRE rules at priority -100 (overridable by game mod rules).
- Auto-generation reads dialogue properties (`mortar`, `mortar_node`, `typewriter`, `voice`, `view`) directly from Tiled objects.
- Uses `SoupruneConfig.game.dialogue_view_default` as fallback when no explicit `view` property is specified on the Tiled object.

**Bug Fixes:**
1. **FRE system ordering race condition** — Added `.after(FRESystemSet::EmitEvents).before(FRESystemSet::ProcessRules)` ordering to the FRE bridge chain to ensure custom dispatch and view actions execute in the correct phase.
2. **Collision query bug** — Changed `TilemapCollidersQuery` filter from `Or<(With<TilemapCollider>, With<ObjectCollider>)>` to `With<TilemapCollider>` only. `ObjectCollider` is a stable identity marker that should never be removed, while `TilemapCollider` is the toggleable collision activation marker.
3. **Boolean arithmetic in FRE conditions** — Added `Bool → i64` conversion in `resolve_int` so expressions like `$button_0_pressed + $button_1_pressed != 2` work correctly when facts are boolean.
4. **StartDialogue blocked by ActiveView** — Moved `StartDialogue` handling from `view_actions.rs` (which requires an active View) to `custom_dispatch.rs` (which operates independently). Overworld interactions have no ActiveView when triggered, so StartDialogue was silently skipped before.
5. **Dialogue View not spawning** — Auto-generated rules now use `dialogue_view_default` from config as the default view path when TMX objects do not specify a `view` property, ensuring the dialogue UI appears.

**Other Changes:**
- Removed `simple_text` dialogue facts and related lifecycle code (fully deprecated).
- Added `SetCollision` and `DespawnView` custom action handlers to the overworld trigger system.
- Cleaned up collision tile generation to only process `collision` kind objects.

### How to test?

1. Run `cargo clippy --workspace --all-targets -D warnings` — should pass with zero warnings.
2. Run `cargo test --workspace --lib --bins` — all tests should pass.
3. Run `cargo run -p souprune --features "debug,bevy/dynamic_linking"` and navigate to the ruins_3 map in the overworld:
   - **Dialogue test**: Walk to the NPC objects (`demo_talk`, `demo_talk_typewriter`) and press confirm. The dialogue box should appear with typewriter text effect. Advancing and closing dialogue should work normally.
   - **Puzzle test**: Step on both button trigger zones. The spikes should retract and their collision should be disabled (player can walk through). Step off one button — spikes should restore and collision re-enabled.

### Screenshots or Videos

N/A — requires runtime testing with game assets.

### Additional Information

- The auto-generated rules use priority -100, allowing game mod rules at higher priority to override the default dialogue behavior for specific objects.
- `ObjectCollider` remains as a stable entity identity marker (never removed), while `TilemapCollider` is used as the toggleable collision flag.
- The FRE bridge system chain now has explicit ordering: `EmitEvents → [FRE Bridge systems].chain() → ProcessRules`.
